### PR TITLE
Support for `note` key

### DIFF
--- a/raindrop-search.el
+++ b/raindrop-search.el
@@ -63,6 +63,11 @@
   :type 'integer
   :group 'raindrop-search)
 
+(defcustom raindrop-search-note-max 20
+  "Maximum characters for notes before truncation."
+  :type 'integer
+  :group 'raindrop-search)
+
 (defcustom raindrop-search-excerpt-max 40
   "Maximum characters for excerpts before truncation."
   :type 'integer
@@ -251,6 +256,13 @@ URL string."
                       (raindrop-search--truncate e0 raindrop-search-excerpt-max)))
          (link    (or (raindrop-search--kv it :link)
                       (raindrop-search--kv it 'link) ""))
+         (note    (if-let ((note (string-trim
+                                  (or (raindrop-search--kv it :note)
+                                      (raindrop-search--kv it 'note)))))
+                      (and (not (string-empty-p note))
+                           (format "%s %s" (propertize "Note:" 'face 'bold)
+                                   (raindrop-search--truncate note raindrop-search-note-max)))
+                    nil))
          (domain* (and-let* ((d (raindrop-search--domain-of link it)))
                     (propertize d 'face 'shadow)))
          (tags    (raindrop-search--tags->strings
@@ -284,7 +296,7 @@ URL string."
          (collstr (when coll-title
                     (propertize (format "[%s]" coll-title)
                                 'face 'raindrop-search-collection))))
-    (string-join (delq nil (list collstr title* desc* tagstr domain*)) "  ")))
+    (string-join (delq nil (list collstr title* desc* tagstr domain* note)) "  ")))
 
 (defun raindrop-search--apply-results (gen items)
   "Apply ITEMS results if GEN matches current generation."

--- a/raindrop-search.el
+++ b/raindrop-search.el
@@ -256,13 +256,12 @@ URL string."
                       (raindrop-search--truncate e0 raindrop-search-excerpt-max)))
          (link    (or (raindrop-search--kv it :link)
                       (raindrop-search--kv it 'link) ""))
-         (note    (if-let ((note (string-trim
-                                  (or (raindrop-search--kv it :note)
-                                      (raindrop-search--kv it 'note)))))
-                      (and (not (string-empty-p note))
-                           (format "%s %s" (propertize "Note:" 'face 'bold)
-                                   (raindrop-search--truncate note raindrop-search-note-max)))
-                    nil))
+         (note    (when-let ((note (string-trim
+                                    (or (raindrop-search--kv it :note)
+                                        (raindrop-search--kv it 'note)))))
+                    (and (not (string-empty-p note))
+                         (format "%s %s" (propertize "Note:" 'face 'bold)
+                                 (raindrop-search--truncate note raindrop-search-note-max)))))
          (domain* (and-let* ((d (raindrop-search--domain-of link it)))
                     (propertize d 'face 'shadow)))
          (tags    (raindrop-search--tags->strings

--- a/raindrop.el
+++ b/raindrop.el
@@ -567,6 +567,7 @@ According to Raindrop API, you can exclude tags using '-tag'."
          (created (alist-get 'created raw))
          (id (alist-get '_id raw))
          (domain (alist-get 'domain raw))
+         (note (alist-get 'note raw))
          (collection (alist-get 'collection raw)))
     (list (cons :id id)
           (cons :link link)
@@ -575,6 +576,7 @@ According to Raindrop API, you can exclude tags using '-tag'."
           (cons :tags tags)
           (cons :domain domain)
           (cons :created created)
+          (cons :note note)
           (cons :collection collection))))
 
 (defun raindrop--normalize-items (items)


### PR DESCRIPTION
- Showing notes in searches if exist.
- It appears at the end of the line with "Note: ...."
- Notes can't be edited in the edit buffer because update API doesn't support it. 
- Added `raindrop-search-note-max` customization.